### PR TITLE
Update Copyright Info to 2019 + spelling fix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Jacob Birkett
+Copyright (c) 2019 Jacob Birkett
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pack/installer.iss
+++ b/pack/installer.iss
@@ -3,7 +3,7 @@
 AllowNetworkDrive=no
 AllowUNCPath=no
 AppContact=support@spikespaz.com
-AppCopyright=Copyright (C) 2018 Jacob Birkett
+AppCopyright=Copyright (C) 2019 Jacob Birkett
 AppId=spikespaz-search-deflector
 AppName=Search Deflector
 AppPublisher=spikespaz

--- a/pack/message.txt
+++ b/pack/message.txt
@@ -1,6 +1,6 @@
 Thank you for using Search Deflector!
 
-Later during this setup, you will be asked to install the "Automatic Updater" module. Note that if you choose to disable this module, you will not recieve any future updates or bug fixes. Please ensure that you are using the latest version of Search Deflector before submitting a bug report.
+Later during this setup, you will be asked to install the "Automatic Updater" module. Note that if you choose to disable this module, you will not receive any future updates or bug fixes. Please ensure that you are using the latest version of Search Deflector before submitting a bug report.
 
 If you have any questions, please consult the wiki first. If your question or problem isn't solved by the wiki content, feel free to create an issue on GitHub or reach out to me via email.
 


### PR DESCRIPTION
Updated copyright information in the documentation and installer, fixed a spelling error.