### PR TITLE
correct update task command-line syntax

### DIFF
--- a/pack/installer.iss
+++ b/pack/installer.iss
@@ -101,7 +101,7 @@ Filename: "schtasks"; \
     Flags: runhidden; \
     Components: updater
 Filename: "schtasks"; \
-    Parameters: "/CHANGE /TN ""Search Deflector Updater"" /TR ""{app}\configure.exe -u"""; \
+    Parameters: "/CHANGE /TN ""Search Deflector Updater"" /TR ""'{app}\configure.exe' -u"""; \
     Flags: runhidden; \
     Components: updater
 


### PR DESCRIPTION
Previously, due to a space in the path to `configure.exe`, the update task's action would end up as in the image, causing the updater to always fail.
![image](https://user-images.githubusercontent.com/8661717/104118010-8608bd80-52da-11eb-9c10-d7d968b1d06c.png)

Adding single quotes to the path solves the issue.